### PR TITLE
Remove references to non-existing code in `__load__.zeek`.

### DIFF
--- a/analyzer/__load__.zeek
+++ b/analyzer/__load__.zeek
@@ -1,2 +1,0 @@
-@load-sigs ./dpd.sig
-@load ./main.zeek


### PR DESCRIPTION
This file was created from a template. The referenced files initially
existed, but were removed since they were not needed; while doing that
we forgot to remove the references to them.